### PR TITLE
Refresh ADOT layer pins and clean up test/deploy workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-node test-python require-python build-appsignals build-otel smoke smoke-appsignals smoke-otel \
+.PHONY: test install-node-deps test-node test-python require-python build-appsignals build-otel smoke smoke-appsignals smoke-otel \
 	check-adot-layers check-adot-layers-appsignals check-adot-layers-otel \
 	update-adot-layers update-adot-layers-appsignals update-adot-layers-otel
 
@@ -6,14 +6,18 @@ APPSIGNALS_TEMPLATE := deployments/appsignals/template.yaml
 APPSIGNALS_CONFIG := deployments/appsignals/samconfig.toml
 OTEL_TEMPLATE := deployments/otel/template.yaml
 OTEL_CONFIG := deployments/otel/samconfig.toml
+NODE_API_DIR := src/node-api
 AWS_REGION ?= us-east-1
 STACK_NAME_APPSIGNALS ?= adot-serverless-demo-appsignals
 STACK_NAME_OTEL ?= adot-serverless-demo-otel
 
 test: test-node test-python
 
-test-node:
-	npm test --prefix src/node-api
+install-node-deps:
+	npm install --prefix $(NODE_API_DIR) --no-package-lock --no-save
+
+test-node: install-node-deps
+	npm test --prefix $(NODE_API_DIR)
 
 require-python:
 	@python3 -c 'import sys; version = sys.version_info[:3]; min_version = (3, 12, 0); sys.exit(f"Python 3.12+ is required for local repo commands; found {sys.version.split()[0]}") if version < min_version else None'

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,20 @@ APPSIGNALS_CONFIG := deployments/appsignals/samconfig.toml
 OTEL_TEMPLATE := deployments/otel/template.yaml
 OTEL_CONFIG := deployments/otel/samconfig.toml
 NODE_API_DIR := src/node-api
+NODE_API_PACKAGE_JSON := $(NODE_API_DIR)/package.json
+NODE_API_INSTALL_STAMP := $(NODE_API_DIR)/node_modules/.install-stamp
 AWS_REGION ?= us-east-1
 STACK_NAME_APPSIGNALS ?= adot-serverless-demo-appsignals
 STACK_NAME_OTEL ?= adot-serverless-demo-otel
 
 test: test-node test-python
 
-install-node-deps:
+install-node-deps: $(NODE_API_INSTALL_STAMP)
+
+$(NODE_API_INSTALL_STAMP): $(NODE_API_PACKAGE_JSON)
 	npm install --prefix $(NODE_API_DIR) --no-package-lock --no-save
+	@mkdir -p $(dir $@)
+	@touch $@
 
 test-node: install-node-deps
 	npm test --prefix $(NODE_API_DIR)

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Both deployment configurations share:
 - [Enable your applications on Lambda](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Signals-Enable-LambdaMain.html)
 - [Monitor application performance with Amazon CloudWatch Application Signals](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-application-signals.html)
 - [AWS Distro for OpenTelemetry Lambda](https://aws-otel.github.io/docs/getting-started/lambda/)
-- [AWS Distro for OpenTelemetry Lambda Support For Python](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python/)
-- [AWS Distro for OpenTelemetry Lambda Support For JavaScript](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js/)
+- [Historical reference only: AWS Distro for OpenTelemetry Lambda Support For Python](https://aws-otel.github.io/docs/getting-started/lambda/lambda-python/)
+- [Historical reference only: AWS Distro for OpenTelemetry Lambda Support For JavaScript](https://aws-otel.github.io/docs/getting-started/lambda/lambda-js/)
 - [AWS::ApplicationSignals::Discovery](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-applicationsignals-discovery.html)
+
+The Python and JavaScript pages above are kept only as historical reference. They are marked as the legacy ADOT Lambda approach and describe the older collector-based path, which this demo does not use.
 
 ## Architecture
 
@@ -185,7 +187,7 @@ The `appsignals` deployment additionally uses:
 The template is intentionally pinned to `us-east-1`, including the Node.js and Python ADOT layer ARNs.
 
 > [!NOTE]
-> As of March 7, 2026, the ADOT Python Lambda layer docs list support through Python 3.13, and the Lambda Application Signals runtime list also stops at Python 3.13. `python3.14` is not yet supported by the ADOT Python Lambda layer for this integration, so this demo pins the Python functions to `python3.13`.
+> As of April 21, 2026, AWS Lambda itself supports `python3.14`, but the current ADOT Lambda docs and the Lambda Application Signals runtime list stop at Python 3.13. This demo therefore pins the Python functions to `python3.13`.
 
 ## Deployment Configurations
 
@@ -196,18 +198,20 @@ Choose one deployment entrypoint:
 - [OTel deployment configuration](deployments/otel/README.md)
   This guide documents an important Lambda-specific OTLP detail: the optimized ADOT Lambda layers need `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, not just the generic OTLP endpoint variable, to avoid the Lambda UDP fallback path.
 
+A default `samconfig.toml` is committed in each deployment directory to simplify the first deploy. Treat it as a starting point. Adjust it to match your stack names, Region, and parameter values when needed.
+
 Canonical commands:
 
 ```bash
 cd deployments/appsignals
-sam build -t template.yaml --config-file samconfig.toml
-sam deploy -t template.yaml --config-file samconfig.toml --guided
+sam build -t template.yaml
+sam deploy -t template.yaml
 ```
 
 ```bash
 cd deployments/otel
-sam build -t template.yaml --config-file samconfig.toml
-sam deploy -t template.yaml --config-file samconfig.toml --guided
+sam build -t template.yaml
+sam deploy -t template.yaml
 ```
 
 ## Prerequisites
@@ -234,6 +238,8 @@ just test
 
 > [!NOTE]
 > `src/node-api/package-lock.json` is intentionally not committed. This repository is a demo/reference for the SAM architecture and ADOT/Application Signals wiring, not a pinned production dependency baseline.
+>
+> On a fresh checkout, `make test` and `just test` install the Node.js test dependencies into `src/node-api/node_modules` without writing a lockfile.
 
 You can also inspect sample invoke payloads in [`events/http-submit-ok.json`](events/http-submit-ok.json), [`events/sqs-work.json`](events/sqs-work.json), and [`events/s3-artifact.json`](events/s3-artifact.json).
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Choose one deployment entrypoint:
 - [OTel deployment configuration](deployments/otel/README.md)
   This guide documents an important Lambda-specific OTLP detail: the optimized ADOT Lambda layers need `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, not just the generic OTLP endpoint variable, to avoid the Lambda UDP fallback path.
 
-A default `samconfig.toml` is committed in each deployment directory to simplify the first deploy. Treat it as a starting point. Adjust it to match your stack names, Region, and parameter values when needed.
+A default `samconfig.toml` is committed in each deployment directory to simplify the first deploy. Treat it as a starting point. Adjust it to match your stack names, Region, and parameter values when needed. If you change Region, also update the pinned `NodeAdotLayerArn` and `PythonAdotLayerArn` values for that Region, or run `make update-adot-layers` or `just update-adot-layers`.
 
 Canonical commands:
 

--- a/deployments/appsignals/README.md
+++ b/deployments/appsignals/README.md
@@ -31,7 +31,7 @@ Committed defaults:
 - ADOT layer ARNs for Node.js 22 and Python 3.13
 - `SlowModeDelaySeconds=6`
 
-The committed `samconfig.toml` is a starting point. Edit it if you want different stack names, Regions, or parameter values.
+The committed `samconfig.toml` is a starting point. Edit it if you want different stack names, Regions, or parameter values. If you change Region, also update `NodeAdotLayerArn` and `PythonAdotLayerArn` for that Region, or run `make update-adot-layers` or `just update-adot-layers`.
 
 ## Before You Deploy
 

--- a/deployments/appsignals/README.md
+++ b/deployments/appsignals/README.md
@@ -15,13 +15,13 @@ It keeps the current observability wiring:
 Build from this directory:
 
 ```bash
-sam build -t template.yaml --config-file samconfig.toml
+sam build -t template.yaml
 ```
 
-Deploy interactively:
+Deploy with the committed defaults:
 
 ```bash
-sam deploy -t template.yaml --config-file samconfig.toml --guided
+sam deploy -t template.yaml
 ```
 
 Committed defaults:
@@ -30,6 +30,8 @@ Committed defaults:
 - region: `us-east-1`
 - ADOT layer ARNs for Node.js 22 and Python 3.13
 - `SlowModeDelaySeconds=6`
+
+The committed `samconfig.toml` is a starting point. Edit it if you want different stack names, Regions, or parameter values.
 
 ## Before You Deploy
 

--- a/deployments/appsignals/samconfig.toml
+++ b/deployments/appsignals/samconfig.toml
@@ -8,8 +8,8 @@ region = "us-east-1"
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
     "SlowModeDelaySeconds=6",
-    "NodeAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:12",
-    "PythonAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:24",
+    "NodeAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:13",
+    "PythonAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:25",
 ]
 image_repositories = []
 

--- a/deployments/appsignals/template.yaml
+++ b/deployments/appsignals/template.yaml
@@ -14,11 +14,11 @@ Parameters:
     Description: Delay used by the demo worker when a job is submitted with mode=slow.
   NodeAdotLayerArn:
     Type: String
-    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:12
+    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:13
     Description: ADOT Lambda layer ARN for the Node.js functions.
   PythonAdotLayerArn:
     Type: String
-    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:24
+    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:25
     Description: ADOT Lambda layer ARN for the Python functions.
 
 Globals:

--- a/deployments/otel/README.md
+++ b/deployments/otel/README.md
@@ -54,7 +54,7 @@ Committed defaults:
 - backend secret name: `adot-serverless-demo-otel-backend`
 - backend config version: `2026-03-19-1`
 
-The committed `samconfig.toml` is a starting point. Edit it if you want different stack names, Regions, parameter values, or secret names.
+The committed `samconfig.toml` is a starting point. Edit it if you want different stack names, Regions, parameter values, or secret names. If you change Region, also update `NodeAdotLayerArn` and `PythonAdotLayerArn` for that Region, or run `make update-adot-layers` or `just update-adot-layers`.
 
 ## Required Configuration
 
@@ -123,8 +123,8 @@ For example, after changing the secret:
 ```toml
 parameter_overrides = [
     "SlowModeDelaySeconds=6",
-    "NodeAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:12",
-    "PythonAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:24",
+    "NodeAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:13",
+    "PythonAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:25",
     "OtelBackendSecretName=adot-serverless-demo-otel-backend",
     "OtelBackendConfigVersion=2026-03-19-2",
 ]

--- a/deployments/otel/README.md
+++ b/deployments/otel/README.md
@@ -36,13 +36,13 @@ The endpoint and headers values are resolved from an AWS Secrets Manager `Secret
 Build from this directory:
 
 ```bash
-sam build -t template.yaml --config-file samconfig.toml
+sam build -t template.yaml
 ```
 
-Deploy interactively:
+Deploy with the committed defaults:
 
 ```bash
-sam deploy -t template.yaml --config-file samconfig.toml --guided
+sam deploy -t template.yaml
 ```
 
 Committed defaults:
@@ -53,6 +53,8 @@ Committed defaults:
 - `SlowModeDelaySeconds=6`
 - backend secret name: `adot-serverless-demo-otel-backend`
 - backend config version: `2026-03-19-1`
+
+The committed `samconfig.toml` is a starting point. Edit it if you want different stack names, Regions, parameter values, or secret names.
 
 ## Required Configuration
 
@@ -98,17 +100,15 @@ aws secretsmanager put-secret-value \
   --region us-east-1
 ```
 
-Then either keep the committed secret name or override `OtelBackendSecretName` during `sam deploy --guided`.
+Then either keep the committed secret name or update `OtelBackendSecretName` in `samconfig.toml` before you deploy.
 
-Examples:
+Deploy with the current committed defaults:
 
 ```bash
-sam deploy -t template.yaml \
-  --config-file samconfig.toml \
-  --guided
+sam deploy -t template.yaml
 ```
 
-During the guided deploy, change `OtelBackendSecretName` if you want to use a different secret name or ARN.
+If you want to use a different secret name or ARN, update `OtelBackendSecretName` in `samconfig.toml` first.
 
 CloudFormation dynamic references can be used in resource properties, including Lambda environment variables, but AWS documents that the resolved value may still show up in the target service. In this deployment configuration, the secret is resolved into Lambda environment variables, so treat the function configuration as sensitive.
 
@@ -133,7 +133,7 @@ parameter_overrides = [
 Then run:
 
 ```bash
-sam deploy -t template.yaml --config-file samconfig.toml
+sam deploy -t template.yaml
 ```
 
 ## Expectations

--- a/deployments/otel/samconfig.toml
+++ b/deployments/otel/samconfig.toml
@@ -8,8 +8,8 @@ region = "us-east-1"
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
     "SlowModeDelaySeconds=6",
-    "NodeAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:12",
-    "PythonAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:24",
+    "NodeAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:13",
+    "PythonAdotLayerArn=arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:25",
     "OtelBackendSecretName=adot-serverless-demo-otel-backend",
     "OtelBackendConfigVersion=2026-03-19-1",
 ]

--- a/deployments/otel/template.yaml
+++ b/deployments/otel/template.yaml
@@ -14,11 +14,11 @@ Parameters:
     Description: Delay used by the demo worker when a job is submitted with mode=slow.
   NodeAdotLayerArn:
     Type: String
-    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:12
+    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:13
     Description: ADOT Lambda layer ARN for the Node.js functions.
   PythonAdotLayerArn:
     Type: String
-    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:24
+    Default: arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroPython:25
     Description: ADOT Lambda layer ARN for the Python functions.
   OtelBackendSecretName:
     Type: String

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ appsignals_template := "deployments/appsignals/template.yaml"
 appsignals_config := "deployments/appsignals/samconfig.toml"
 otel_template := "deployments/otel/template.yaml"
 otel_config := "deployments/otel/samconfig.toml"
+node_api_dir := "src/node-api"
 aws_region := env_var_or_default("AWS_REGION", "us-east-1")
 stack_name_appsignals := env_var_or_default("STACK_NAME_APPSIGNALS", "adot-serverless-demo-appsignals")
 stack_name_otel := env_var_or_default("STACK_NAME_OTEL", "adot-serverless-demo-otel")
@@ -13,8 +14,11 @@ default:
 
 test: test-node test-python
 
-test-node:
-    npm test --prefix src/node-api
+install-node-deps:
+    npm install --prefix {{node_api_dir}} --no-package-lock --no-save
+
+test-node: install-node-deps
+    npm test --prefix {{node_api_dir}}
 
 test-python:
     python3 -m unittest discover -s tests/python -v

--- a/justfile
+++ b/justfile
@@ -17,8 +17,8 @@ test: test-node test-python
 install-node-deps:
     stamp="{{node_api_dir}}/node_modules/.install-stamp"; \
     if [ ! -d "{{node_api_dir}}/node_modules" ] || [ ! -f "$stamp" ] || [ "{{node_api_dir}}/package.json" -nt "$stamp" ]; then \
-        npm install --prefix {{node_api_dir}} --no-package-lock --no-save; \
-        mkdir -p "{{node_api_dir}}/node_modules"; \
+        npm install --prefix {{node_api_dir}} --no-package-lock --no-save && \
+        mkdir -p "{{node_api_dir}}/node_modules" && \
         touch "$stamp"; \
     fi
 

--- a/justfile
+++ b/justfile
@@ -15,7 +15,12 @@ default:
 test: test-node test-python
 
 install-node-deps:
-    npm install --prefix {{node_api_dir}} --no-package-lock --no-save
+    stamp="{{node_api_dir}}/node_modules/.install-stamp"; \
+    if [ ! -d "{{node_api_dir}}/node_modules" ] || [ ! -f "$stamp" ] || [ "{{node_api_dir}}/package.json" -nt "$stamp" ]; then \
+        npm install --prefix {{node_api_dir}} --no-package-lock --no-save; \
+        mkdir -p "{{node_api_dir}}/node_modules"; \
+        touch "$stamp"; \
+    fi
 
 test-node: install-node-deps
     npm test --prefix {{node_api_dir}}


### PR DESCRIPTION
## Summary

This change refreshes the pinned ADOT Lambda layer versions and cleans up the repo's local test and deployment workflow guidance.

## What changed

- bumped the pinned ADOT JS and Python layer ARNs in both deployment configurations
- made `make test` and `just test` install transient Node test dependencies in a fresh checkout without writing a lockfile
- clarified that each deployment directory ships a committed default `samconfig.toml` as the deployment starting point
- marked the old per-runtime ADOT pages as historical references only
- removed redundant `--guided` and `--config-file samconfig.toml` usage from the default deployment examples

## Why

The layer pins were behind the latest published versions in `us-east-1`, and the docs still reflected an older guided-deploy flow that no longer matches how this repo is meant to be used. `make test` also failed in a fresh worktree unless `src/node-api/node_modules` had already been installed manually.

Closes #3.

## Validation

- `make test`
- `./scripts/smoke-test.sh adot-serverless-demo-appsignals us-east-1 --modes ok,slow,fail --count 1`
- `./scripts/smoke-test.sh adot-serverless-demo-otel us-east-1 --modes ok,slow,fail --count 1`
- reviewed fresh Lambda logs for both stacks after redeploy
